### PR TITLE
add solo endorsements, bay scrollbar and enter key support in dialogues

### DIFF
--- a/API/src/services/controllerServices.ts
+++ b/API/src/services/controllerServices.ts
@@ -144,27 +144,21 @@ export async function createControllerService(cid: string, name: string, sign: s
 
 /** Parses endorsement string to list of Endorsements. Will return empty if no endorsement given */
 export const parseEndorsement = (endorsement: string | string[]): Endorsement[]  => {
+    const validEndorsements: Endorsement[] = ["T2 APS", "T1 TWR", "T1 APP", "SOLO GG TWR", "SOLO GG APP"];
     let endorsementls: Endorsement[] = [];
+
     if (typeof(endorsement) === 'string') {
-        if (endorsement.match('T2 APS')?.length == 1) {
-            endorsementls.push("T2 APS");
-        }
-        if (endorsement.match('T1 TWR')?.length == 1) {
-            endorsementls.push("T1 TWR");
-        }
-        if (endorsement.match('T1 APP')?.length == 1) {
-            endorsementls.push("T1 APP");
-        }
+        validEndorsements.forEach(validEndorsement => {
+            if (endorsement.match(validEndorsement)?.length === 1) {
+                endorsementls.push(validEndorsement);
+            }
+        });
     } else {
-        if (endorsement.includes("T2 APS")) {
-            endorsementls.push("T2 APS");
-        } 
-        if (endorsement.includes("T1 TWR")) {
-            endorsementls.push("T1 TWR");
-        }
-        if (endorsement.includes("T1 APP")) {
-            endorsementls.push("T1 APP");
-        }
+        validEndorsements.forEach(validEndorsement => {
+            if (endorsement.includes(validEndorsement)) {
+                endorsementls.push(validEndorsement);
+            }
+        });
     }
 
     return endorsementls;

--- a/API/src/types/types.ts
+++ b/API/src/types/types.ts
@@ -39,7 +39,7 @@ export interface SkeletonController {
   rating: Rating;
 };
 
-export type Endorsement = 'NIL' | 'T1 APP' | 'T2 APS' | 'T1 TWR';
+export type Endorsement = 'NIL' | 'T1 APP' | 'T2 APS' | 'T1 TWR' | 'SOLO GG TWR' | 'SOLO GG APP';
 
 export interface NewController extends SkeletonController {
   endorsement: Endorsement[];

--- a/src/pls.vue
+++ b/src/pls.vue
@@ -846,6 +846,9 @@
     refreshTime()
     authorized.value = isAuthorized()
     unsubscribe = subscribe();
+
+    // Add global keydown listener
+    window.addEventListener('keydown', handleDialogueKeypress)
   })
 
   const stopWatch = watch([activeControllers, controllerNames, awayControllers], () => {
@@ -865,7 +868,24 @@
     if (unsubscribe) {
       unsubscribe();
     }
+    // Remove global keydown listener
+    window.removeEventListener('keydown', handleDialogueKeypress)
   })
+
+  function handleDialogueKeypress(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      if (showPauseDialog.value) {
+        event.preventDefault()
+        confirmPause()
+      } else if (showPositionDialog.value) {
+        event.preventDefault()
+        confirmPosition()
+      } else if (showAwayDialog.value) {
+        event.preventDefault()
+        confirmAway()
+      }
+    }
+  }
 
   function onAddPosition() {
     backupControllers.value = true
@@ -898,6 +918,7 @@
   }
 
   function confirmPause() {
+    console.log("confirmPause")
     if(selectedController.value) {
       const controller = controllerNames.value.find(controller => controller.cid === selectedController.value?.cid);
       if(controller) {


### PR DESCRIPTION
* Add possibility to add solo endorsements when creating new controller (GG APP SOLO, GG TWR SOLO.. maybe more?) fixes #20 

* add individual scroll bar per bay, the scroll position is saved and restored after refresh. resolves #26 

* Add enter key functionality in dialogues (end shift, start shift) resolves #23 